### PR TITLE
Do not show certain labels until zoom 1.1

### DIFF
--- a/style.json
+++ b/style.json
@@ -3782,6 +3782,7 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "water_name",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -3818,6 +3819,7 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "water_name",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -4713,6 +4715,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -4766,6 +4769,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -4819,6 +4823,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -4872,6 +4877,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "filter": [
         "all",
         [
@@ -4925,7 +4931,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
-      "maxzoom": 1,
+      "maxzoom": 1.1,
       "filter": [
         "==",
         "class",


### PR DESCRIPTION
Some country and ocean labels near the dateline at zoom level 1 are getting cut off in raster tiles. This is a known issue with tileserver-gl. This changes the visible zoom level for these labels to 1.1 so these errant labels will start to appear in zoom level 2 in raster tiles and in zoom level 1.1 in vector tiles.

This also reduces the busyness of the labels at zoom level one.

cf https://github.com/elastic/osm-bright-gl-style/pull/2