### PR TITLE
Update to v1.9 (OMT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gl-style-package-spec/
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,24 @@
 {
   "name": "@elastic/osm-bring-desaturated-gl-style",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@elastic/osm-bring-desaturated-gl-style",
+      "version": "1.0.0",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "chroma-js": "^2.0.2"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/chroma-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.2.tgz",
+      "integrity": "sha512-VtDXaYcaDr45wheOXasIs4S4IWEjpqh74UfQA0TwoLuBR7TG12ztmjj9JqTIe1sgzVTMDNwSPEJYcw/jYK2TSw=="
+    }
+  },
   "dependencies": {
     "chroma-js": {
       "version": "2.0.2",

--- a/style.json
+++ b/style.json
@@ -4,13 +4,34 @@
   "metadata": {
     "mapbox:type": "template",
     "mapbox:groups": {
-      "1444849364238.8171": {"collapsed": false, "name": "Buildings"},
-      "1444849354174.1904": {"collapsed": true, "name": "Tunnels"},
-      "1444849388993.3071": {"collapsed": false, "name": "Land"},
-      "1444849242106.713": {"collapsed": false, "name": "Places"},
-      "1444849382550.77": {"collapsed": false, "name": "Water"},
-      "1444849345966.4436": {"collapsed": false, "name": "Roads"},
-      "1444849334699.1902": {"collapsed": true, "name": "Bridges"}
+      "1444849364238.8171": {
+        "collapsed": false,
+        "name": "Buildings"
+      },
+      "1444849354174.1904": {
+        "collapsed": true,
+        "name": "Tunnels"
+      },
+      "1444849388993.3071": {
+        "collapsed": false,
+        "name": "Land"
+      },
+      "1444849242106.713": {
+        "collapsed": false,
+        "name": "Places"
+      },
+      "1444849382550.77": {
+        "collapsed": false,
+        "name": "Water"
+      },
+      "1444849345966.4436": {
+        "collapsed": false,
+        "name": "Roads"
+      },
+      "1444849334699.1902": {
+        "collapsed": true,
+        "name": "Bridges"
+      }
     },
     "mapbox:autocomposite": false,
     "openmaptiles:version": "3.x",
@@ -30,34 +51,68 @@
     {
       "id": "background",
       "type": "background",
-      "paint": {"background-color": "rgba(255,255,255,1)"}
+      "paint": {
+        "background-color": "rgba(255,255,255,1)"
+      }
     },
     {
       "id": "landcover-glacier",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": ["==", "subclass", "glacier"],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "==",
+        "subclass",
+        "glacier"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
       }
     },
     {
       "id": "landuse-residential",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": ["==", "class", "residential"],
+      "filter": [
+        "==",
+        "class",
+        "residential"
+      ],
       "paint": {
         "fill-color": {
           "base": 1,
           "stops": [
-            [12, "rgba(248,248,248,0.4)"],
-            [16, "rgba(248,248,248,0.2)"]
+            [
+              12,
+              "rgba(248,248,248,0.4)"
+            ],
+            [
+              16,
+              "rgba(248,248,248,0.2)"
+            ]
           ]
         }
       }
@@ -65,127 +120,252 @@
     {
       "id": "landuse-commercial",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["==", "class", "commercial"]
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "commercial"
+        ]
       ],
-      "paint": {"fill-color": "rgba(228,228,228,0.23)"}
+      "paint": {
+        "fill-color": "rgba(228,228,228,0.23)"
+      }
     },
     {
       "id": "landuse-industrial",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["==", "class", "industrial"]
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "industrial"
+        ]
       ],
-      "paint": {"fill-color": "rgba(255,255,249,0.34)"}
+      "paint": {
+        "fill-color": "rgba(255,255,249,0.34)"
+      }
     },
     {
       "id": "park",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "park",
-      "filter": ["==", "$type", "Polygon"],
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
       "paint": {
         "fill-color": "rgba(244,244,244,1)",
-        "fill-opacity": {"base": 1.8, "stops": [[9, 0.5], [12, 0.2]]}
+        "fill-opacity": {
+          "base": 1.8,
+          "stops": [
+            [
+              9,
+              0.5
+            ],
+            [
+              12,
+              0.2
+            ]
+          ]
+        }
       }
     },
     {
       "id": "park-outline",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "park",
-      "filter": ["==", "$type", "Polygon"],
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
       "layout": {},
       "paint": {
         "line-color": {
           "base": 1,
           "stops": [
-            [6, "rgba(149,186,121,0.36)"],
-            [8, "rgba(149,186,121,0.66)"]
+            [
+              6,
+              "rgba(149,186,121,0.36)"
+            ],
+            [
+              8,
+              "rgba(149,186,121,0.66)"
+            ]
           ]
         },
-        "line-dasharray": [3, 3]
+        "line-dasharray": [
+          3,
+          3
+        ]
       }
     },
     {
       "id": "landuse-cemetery",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": ["==", "class", "cemetery"],
-      "paint": {"fill-color": "rgba(244,244,244,1)"}
+      "filter": [
+        "==",
+        "class",
+        "cemetery"
+      ],
+      "paint": {
+        "fill-color": "rgba(244,244,244,1)"
+      }
     },
     {
       "id": "landuse-hospital",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": ["==", "class", "hospital"],
-      "paint": {"fill-color": "rgba(247,247,247,1)"}
+      "filter": [
+        "==",
+        "class",
+        "hospital"
+      ],
+      "paint": {
+        "fill-color": "rgba(247,247,247,1)"
+      }
     },
     {
       "id": "landuse-school",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": ["==", "class", "school"],
-      "paint": {"fill-color": "rgba(252,252,252,1)"}
+      "filter": [
+        "==",
+        "class",
+        "school"
+      ],
+      "paint": {
+        "fill-color": "rgba(252,252,252,1)"
+      }
     },
     {
       "id": "landuse-railway",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landuse",
-      "filter": ["==", "class", "railway"],
-      "paint": {"fill-color": "rgba(248,248,248,0.4)"}
+      "filter": [
+        "==",
+        "class",
+        "railway"
+      ],
+      "paint": {
+        "fill-color": "rgba(248,248,248,0.4)"
+      }
     },
     {
       "id": "landcover-wood",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": ["==", "class", "wood"],
+      "filter": [
+        "==",
+        "class",
+        "wood"
+      ],
       "paint": {
         "fill-color": "rgba(138,181,113,1)",
         "fill-opacity": 0.1,
         "fill-outline-color": "rgba(19,19,19,0.03)",
-        "fill-antialias": {"base": 1, "stops": [[0, false], [9, true]]}
+        "fill-antialias": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              9,
+              true
+            ]
+          ]
+        }
       }
     },
     {
       "id": "landcover-grass",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": ["==", "class", "grass"],
-      "paint": {"fill-color": "rgba(244,244,244,1)", "fill-opacity": 1}
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ],
+      "paint": {
+        "fill-color": "rgba(244,244,244,1)",
+        "fill-opacity": 1
+      }
     },
     {
       "id": "landcover-grass-park",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
       "source": "openmaptiles",
       "source-layer": "park",
-      "filter": ["==", "class", "public_park"],
-      "paint": {"fill-color": "rgba(244,244,244,1)", "fill-opacity": 0.8}
+      "filter": [
+        "==",
+        "class",
+        "public_park"
+      ],
+      "paint": {
+        "fill-color": "rgba(244,244,244,1)",
+        "fill-opacity": 0.8
+      }
     },
     {
       "id": "waterway_tunnel",
@@ -195,106 +375,271 @@
       "minzoom": 14,
       "filter": [
         "all",
-        ["in", "class", "river", "stream", "canal"],
-        ["==", "brunnel", "tunnel"]
+        [
+          "in",
+          "class",
+          "river",
+          "stream",
+          "canal"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": {"line-cap": "round"},
+      "layout": {
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
-        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]},
-        "line-dasharray": [2, 4]
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          4
+        ]
       }
     },
     {
       "id": "waterway-other",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": ["!in", "class", "canal", "river", "stream"],
-      "layout": {"line-cap": "round"},
+      "filter": [
+        "!in",
+        "class",
+        "canal",
+        "river",
+        "stream"
+      ],
+      "layout": {
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
-        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 2]]}
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
       }
     },
     {
       "id": "waterway-stream-canal",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "waterway",
       "filter": [
         "all",
-        ["in", "class", "canal", "stream"],
-        ["!=", "brunnel", "tunnel"]
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": {"line-cap": "round"},
+      "layout": {
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
-        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
       }
     },
     {
       "id": "waterway-river",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "waterway",
-      "filter": ["all", ["==", "class", "river"], ["!=", "brunnel", "tunnel"]],
-      "layout": {"line-cap": "round"},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
-        "line-width": {"base": 1.2, "stops": [[10, 0.8], [20, 6]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
       }
     },
     {
       "id": "water-offset",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "water",
       "maxzoom": 8,
-      "filter": ["==", "$type", "Polygon"],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-opacity": 1,
         "fill-color": "rgba(207,213,221,1)",
-        "fill-translate": {"base": 1, "stops": [[6, [2, 0]], [8, [0, 0]]]}
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              6,
+              [
+                2,
+                0
+              ]
+            ],
+            [
+              8,
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
       }
     },
     {
       "id": "water",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "water",
-      "layout": {"visibility": "visible"},
-      "paint": {"fill-color": "rgba(231,231,231,1)"}
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(231,231,231,1)"
+      }
     },
     {
       "id": "landcover-ice-shelf",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849382550.77"},
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
       "source": "openmaptiles",
       "source-layer": "landcover",
-      "filter": ["==", "subclass", "ice_shelf"],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "==",
+        "subclass",
+        "ice_shelf"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
       }
     },
     {
       "id": "building",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849364238.8171"},
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
       "source": "openmaptiles",
       "source-layer": "building",
       "paint": {
         "fill-color": {
           "base": 1,
-          "stops": [[15.5, "rgba(252,252,252,1)"], [16, "rgba(236,236,236,1)"]]
+          "stops": [
+            [
+              15.5,
+              "rgba(252,252,252,1)"
+            ],
+            [
+              16,
+              "rgba(236,236,236,1)"
+            ]
+          ]
         },
         "fill-antialias": true
       }
@@ -302,225 +647,633 @@
     {
       "id": "building-top",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849364238.8171"},
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
       "source": "openmaptiles",
       "source-layer": "building",
-      "layout": {"visibility": "visible"},
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
-        "fill-translate": {"base": 1, "stops": [[14, [0, 0]], [16, [-2, -2]]]},
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              14,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              16,
+              [
+                -2,
+                -2
+              ]
+            ]
+          ]
+        },
         "fill-outline-color": "rgba(236,236,236,1)",
         "fill-color": "rgba(252,252,252,1)",
-        "fill-opacity": {"base": 1, "stops": [[13, 0], [16, 1]]}
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-service-track-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "service", "track"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(222,222,222,1)",
-        "line-dasharray": [0.5, 0.25],
-        "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              20,
+              11
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-minor-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "minor"]],
-      "layout": {"line-join": "round"},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor"
+        ]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(222,222,222,1)",
-        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "tunnel-secondary-tertiary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-trunk-primary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "primary", "trunk"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         }
       }
     },
     {
       "id": "tunnel-motorway-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["==", "class", "motorway"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
       ],
-      "layout": {"line-join": "round", "visibility": "visible"},
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
-        "line-dasharray": [0.5, 0.25],
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         }
       }
     },
     {
       "id": "tunnel-path",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "tunnel"], ["==", "class", "path"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
       ],
       "paint": {
         "line-color": "rgba(206,206,206,1)",
-        "line-dasharray": [1.5, 0.75],
-        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-service-track",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "service", "track"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
-        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15.5,
+              0
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              20,
+              7.5
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-minor",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["==", "class", "minor_road"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor_road"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-secondary-tertiary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,253,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              10
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-trunk-primary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["in", "class", "primary", "trunk"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,253,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-motorway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "tunnel"],
-        ["==", "class", "motorway"]
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
       ],
-      "layout": {"line-join": "round", "visibility": "visible"},
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(253,238,220,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "tunnel-railway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "rail"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
-        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]},
-        "line-dasharray": [2, 2]
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          2
+        ]
       }
     },
     {
@@ -528,22 +1281,44 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["in", "class", "ferry"]],
-      "layout": {"line-join": "round", "visibility": "visible"},
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "ferry"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(167,168,169,1)",
         "line-width": 1.1,
-        "line-dasharray": [2, 2]
+        "line-dasharray": [
+          2,
+          2
+        ]
       }
     },
     {
       "id": "aeroway-taxiway-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": ["all", ["in", "class", "taxiway"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "taxiway"
+        ]
+      ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -551,18 +1326,39 @@
       },
       "paint": {
         "line-color": "rgba(169,169,169,1)",
-        "line-width": {"base": 1.5, "stops": [[11, 2], [17, 12]]},
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              2
+            ],
+            [
+              17,
+              12
+            ]
+          ]
+        },
         "line-opacity": 1
       }
     },
     {
       "id": "aeroway-runway-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": ["all", ["in", "class", "runway"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "runway"
+        ]
+      ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -570,39 +1366,86 @@
       },
       "paint": {
         "line-color": "rgba(169,169,169,1)",
-        "line-width": {"base": 1.5, "stops": [[11, 5], [17, 55]]},
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              5
+            ],
+            [
+              17,
+              55
+            ]
+          ]
+        },
         "line-opacity": 1
       }
     },
     {
       "id": "aeroway-area",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 4,
       "filter": [
         "all",
-        ["==", "$type", "Polygon"],
-        ["in", "class", "runway", "taxiway"]
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "in",
+          "class",
+          "runway",
+          "taxiway"
+        ]
       ],
-      "layout": {"visibility": "visible"},
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
-        "fill-opacity": {"base": 1, "stops": [[13, 0], [14, 1]]},
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              14,
+              1
+            ]
+          ]
+        },
         "fill-color": "rgba(255,255,255,1)"
       }
     },
     {
       "id": "aeroway-taxiway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 4,
       "filter": [
         "all",
-        ["in", "class", "taxiway"],
-        ["==", "$type", "LineString"]
+        [
+          "in",
+          "class",
+          "taxiway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -611,21 +1454,55 @@
       },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
-        "line-width": {"base": 1.5, "stops": [[11, 1], [17, 10]]},
-        "line-opacity": {"base": 1, "stops": [[11, 0], [12, 1]]}
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              17,
+              10
+            ]
+          ]
+        },
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "aeroway-runway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "aeroway",
       "minzoom": 4,
       "filter": [
         "all",
-        ["in", "class", "runway"],
-        ["==", "$type", "LineString"]
+        [
+          "in",
+          "class",
+          "runway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -634,18 +1511,50 @@
       },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
-        "line-width": {"base": 1.5, "stops": [[11, 4], [17, 50]]},
-        "line-opacity": {"base": 1, "stops": [[11, 0], [12, 1]]}
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              4
+            ],
+            [
+              17,
+              50
+            ]
+          ]
+        },
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-area",
       "type": "fill",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["==", "$type", "Polygon"],
-      "layout": {"visibility": "visible"},
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(244,244,244,0.56)",
         "fill-outline-color": "rgba(222,222,222,1)",
@@ -656,35 +1565,73 @@
     {
       "id": "highway-motorway-link-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 12,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "motorway_link"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-link-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
         [
           "in",
           "class",
@@ -704,45 +1651,121 @@
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-minor-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!=", "brunnel", "tunnel"],
-          ["in", "class", "minor", "service", "track"]
+          [
+            "!=",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "minor",
+            "service",
+            "track"
+          ]
         ]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(222,222,222,1)",
-        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-secondary-tertiary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -752,20 +1775,43 @@
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-primary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 5,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "primary"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary"
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -774,24 +1820,63 @@
       },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
-        "line-opacity": {"stops": [[7, 0], [8, 1]]},
+        "line-opacity": {
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.2,
-          "stops": [[7, 0], [8, 0.6], [9, 1.5], [20, 22]]
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              0.6
+            ],
+            [
+              9,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-trunk-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 5,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "trunk"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk"
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -800,24 +1885,63 @@
       },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
-        "line-opacity": {"stops": [[5, 0], [6, 1]]},
+        "line-opacity": {
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-motorway-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 4,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "motorway"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
       ],
       "layout": {
         "line-cap": "butt",
@@ -828,59 +1952,163 @@
         "line-color": "rgba(228,195,168,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[4, 0], [5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         },
-        "line-opacity": {"stops": [[4, 0], [5, 1]]}
+        "line-opacity": {
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-path",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["!in", "brunnel", "bridge", "tunnel"], ["==", "class", "path"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
       ],
       "paint": {
         "line-color": "rgba(206,206,206,1)",
-        "line-dasharray": [1.5, 0.75],
-        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]}
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-motorway-link",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 12,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["==", "class", "motorway_link"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,225,189,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-link",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
         [
           "in",
           "class",
@@ -899,42 +2127,106 @@
         "line-color": "rgba(255,255,225,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
         }
       }
     },
     {
       "id": "highway-minor",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!=", "brunnel", "tunnel"],
-          ["in", "class", "minor", "service", "track"]
+          [
+            "!=",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "minor",
+            "service",
+            "track"
+          ]
         ]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-secondary-tertiary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
       "layout": {
         "line-cap": "round",
@@ -943,22 +2235,53 @@
       },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              8,
+              0.5
+            ],
+            [
+              20,
+              13
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-primary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["in", "class", "primary"]
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "primary"
+          ]
         ]
       ],
       "layout": {
@@ -968,22 +2291,53 @@
       },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
-        "line-width": {"base": 1.2, "stops": [[8.5, 0], [9, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8.5,
+              0
+            ],
+            [
+              9,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-trunk",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["in", "class", "trunk"]
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "trunk"
+          ]
         ]
       ],
       "layout": {
@@ -993,23 +2347,54 @@
       },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "highway-motorway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 5,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "motorway"]
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
         ]
       ],
       "layout": {
@@ -1019,151 +2404,411 @@
       },
       "paint": {
         "line-color": "rgba(255,225,189,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway-transit",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "transit"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "tunnel"
+          ]
+        ]
       ],
-      "layout": {"visibility": "visible"},
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(203,203,203,0.77)",
-        "line-width": {"base": 1.4, "stops": [[14, 0.4], [20, 1]]}
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway-transit-hatching",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "transit"], ["!in", "brunnel", "tunnel"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "transit"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "tunnel"
+          ]
+        ]
       ],
-      "layout": {"visibility": "visible"},
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(203,203,203,0.68)",
-        "line-dasharray": [0.2, 8],
-        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 2], [20, 6]]}
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway-service",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "rail"], ["has", "service"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "rail"
+          ],
+          [
+            "has",
+            "service"
+          ]
+        ]
       ],
       "paint": {
         "line-color": "rgba(203,203,203,0.77)",
-        "line-width": {"base": 1.4, "stops": [[14, 0.4], [20, 1]]}
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway-service-hatching",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "class", "rail"], ["has", "service"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "rail"
+          ],
+          [
+            "has",
+            "service"
+          ]
+        ]
       ],
-      "layout": {"visibility": "visible"},
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "line-color": "rgba(203,203,203,0.68)",
-        "line-dasharray": [0.2, 8],
-        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 2], [20, 6]]}
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!has", "service"],
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "rail"]
+          [
+            "!has",
+            "service"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "rail"
+          ]
         ]
       ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
-        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
       }
     },
     {
       "id": "railway-hatching",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
         [
           "all",
-          ["!has", "service"],
-          ["!in", "brunnel", "bridge", "tunnel"],
-          ["==", "class", "rail"]
+          [
+            "!has",
+            "service"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "rail"
+          ]
         ]
       ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
-        "line-dasharray": [0.2, 8],
-        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-motorway-link-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["==", "class", "motorway_link"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-link-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
         [
           "in",
           "class",
@@ -1173,136 +2818,337 @@
           "trunk_link"
         ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-secondary-tertiary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-opacity": 1,
-        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 28]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              28
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-trunk-primary-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["in", "class", "primary", "trunk"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(232,190,156,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 26]]
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              26
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-motorway-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["==", "class", "motorway"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-path-casing",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
       ],
       "paint": {
         "line-color": "rgba(255,255,255,1)",
-        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-path",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["all", ["==", "brunnel", "bridge"], ["==", "class", "path"]]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
       ],
       "paint": {
         "line-color": "rgba(206,206,206,1)",
-        "line-width": {"base": 1.2, "stops": [[15, 1.2], [20, 4]]},
-        "line-dasharray": [1.5, 0.75]
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        },
+        "line-dasharray": [
+          1.5,
+          0.75
+        ]
       }
     },
     {
       "id": "bridge-motorway-link",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["==", "class", "motorway_link"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,225,189,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-link",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
         [
           "in",
           "class",
@@ -1312,89 +3158,257 @@
           "trunk_link"
         ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
         }
       }
     },
     {
       "id": "bridge-secondary-tertiary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 20]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-trunk-primary",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["in", "class", "primary", "trunk"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,255,225,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-motorway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
-        ["==", "brunnel", "bridge"],
-        ["==", "class", "motorway"]
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(255,225,189,1)",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-railway",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "brunnel", "bridge"], ["==", "class", "rail"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
-        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
       }
     },
     {
       "id": "bridge-railway-hatching",
       "type": "line",
-      "metadata": {"mapbox:group": "1444849334699.1902"},
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "brunnel", "bridge"], ["==", "class", "rail"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
-        "line-dasharray": [0.2, 8],
-        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
       }
     },
     {
@@ -1403,11 +3417,30 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["==", "class", "cable_car"],
-      "layout": {"visibility": "visible", "line-cap": "round"},
+      "filter": [
+        "==",
+        "class",
+        "cable_car"
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(195,195,195,1)",
-        "line-width": {"base": 1, "stops": [[11, 1], [19, 2.5]]}
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              19,
+              2.5
+            ]
+          ]
+        }
       }
     },
     {
@@ -1416,12 +3449,34 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["==", "class", "cable_car"],
-      "layout": {"visibility": "visible", "line-cap": "round"},
+      "filter": [
+        "==",
+        "class",
+        "cable_car"
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "round"
+      },
       "paint": {
         "line-color": "rgba(195,195,195,1)",
-        "line-width": {"base": 1, "stops": [[11, 3], [19, 5.5]]},
-        "line-dasharray": [2, 3]
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              19,
+              5.5
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          3
+        ]
       }
     },
     {
@@ -1431,15 +3486,50 @@
       "source-layer": "boundary",
       "filter": [
         "all",
-        [">=", "admin_level", 4],
-        ["<=", "admin_level", 8],
-        ["!=", "maritime", 1]
+        [
+          ">=",
+          "admin_level",
+          4
+        ],
+        [
+          "<=",
+          "admin_level",
+          8
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ]
       ],
-      "layout": {"line-join": "round"},
+      "layout": {
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(173,173,173,1)",
-        "line-dasharray": [3, 1, 1, 1],
-        "line-width": {"base": 1.4, "stops": [[4, 0.4], [5, 1], [12, 3]]}
+        "line-dasharray": [
+          3,
+          1,
+          1,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              4,
+              0.4
+            ],
+            [
+              5,
+              1
+            ],
+            [
+              12,
+              3
+            ]
+          ]
+        }
       }
     },
     {
@@ -1449,16 +3539,48 @@
       "source-layer": "boundary",
       "filter": [
         "all",
-        ["==", "admin_level", 2],
-        ["!=", "maritime", 1],
-        ["!=", "disputed", 1]
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "!=",
+          "disputed",
+          1
+        ]
       ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(179,179,179,1)",
         "line-width": {
           "base": 1,
-          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
         }
       }
     },
@@ -1467,14 +3589,49 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "filter": ["all", ["!=", "maritime", 1], ["==", "disputed", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "==",
+          "disputed",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(190,190,190,1)",
-        "line-dasharray": [1, 3],
+        "line-dasharray": [
+          1,
+          3
+        ],
         "line-width": {
           "base": 1,
-          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
         }
       }
     },
@@ -1483,15 +3640,59 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "filter": ["all", ["in", "admin_level", 2, 4], ["==", "maritime", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": [
+        "all",
+        [
+          "in",
+          "admin_level",
+          2,
+          4
+        ],
+        [
+          "==",
+          "maritime",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "rgba(201,201,201,1)",
         "line-width": {
           "base": 1,
-          "stops": [[0, 0.6], [4, 1.4], [5, 2], [12, 8]]
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
         },
-        "line-opacity": {"stops": [[6, 0.6], [10, 1]]}
+        "line-opacity": {
+          "stops": [
+            [
+              6,
+              0.6
+            ],
+            [
+              10,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -1500,9 +3701,22 @@
       "source": "openmaptiles",
       "source-layer": "waterway",
       "minzoom": 13,
-      "filter": ["all", ["==", "$type", "LineString"], ["has", "name"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
       "layout": {
-        "text-font": ["Noto Sans Italic"],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
         "text-size": 14,
         "text-field": "{name:latin} {name:nonlatin}",
         "text-max-width": 5,
@@ -1522,9 +3736,15 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "water_name",
-      "filter": ["==", "$type", "LineString"],
+      "filter": [
+        "==",
+        "$type",
+        "LineString"
+      ],
       "layout": {
-        "text-font": ["Noto Sans Italic"],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
         "text-size": 14,
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 5,
@@ -1545,9 +3765,23 @@
       "source": "openmaptiles",
       "source-layer": "water_name",
       "minzoom": 1.1,
-      "filter": ["all", ["==", "$type", "Point"], ["==", "class", "ocean"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "ocean"
+        ]
+      ],
       "layout": {
-        "text-font": ["Noto Sans Italic"],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
         "text-size": 14,
         "text-field": "{name:latin}",
         "text-max-width": 5,
@@ -1568,10 +3802,35 @@
       "source": "openmaptiles",
       "source-layer": "water_name",
       "minzoom": 1.1,
-      "filter": ["all", ["==", "$type", "Point"], ["!in", "class", "ocean"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "!in",
+          "class",
+          "ocean"
+        ]
+      ],
       "layout": {
-        "text-font": ["Noto Sans Italic"],
-        "text-size": {"stops": [[0, 10], [6, 14]]},
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              0,
+              10
+            ],
+            [
+              6,
+              14
+            ]
+          ]
+        },
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 5,
         "text-rotation-alignment": "map",
@@ -1592,14 +3851,31 @@
       "source": "openmaptiles",
       "source-layer": "poi",
       "minzoom": 16,
-      "filter": ["all", ["==", "$type", "Point"], [">=", "rank", 25]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          ">=",
+          "rank",
+          25
+        ]
+      ],
       "layout": {
         "text-padding": 2,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-anchor": "top",
         "icon-image": "{class}_11",
         "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-offset": [0, 0.6],
+        "text-offset": [
+          0,
+          0.6
+        ],
         "text-size": 12,
         "text-max-width": 9
       },
@@ -1618,17 +3894,34 @@
       "minzoom": 15,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["<=", "rank", 24],
-        [">=", "rank", 15]
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          24
+        ],
+        [
+          ">=",
+          "rank",
+          15
+        ]
       ],
       "layout": {
         "text-padding": 2,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-anchor": "top",
         "icon-image": "{class}_11",
         "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-offset": [0, 0.6],
+        "text-offset": [
+          0,
+          0.6
+        ],
         "text-size": 12,
         "text-max-width": 9
       },
@@ -1647,17 +3940,33 @@
       "minzoom": 14,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["<=", "rank", 14],
-        ["has", "name"]
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          14
+        ],
+        [
+          "has",
+          "name"
+        ]
       ],
       "layout": {
         "text-padding": 2,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-anchor": "top",
         "icon-image": "{class}_11",
         "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-offset": [0, 0.6],
+        "text-offset": [
+          0,
+          0.6
+        ],
         "text-size": 12,
         "text-max-width": 9
       },
@@ -1676,18 +3985,38 @@
       "minzoom": 13,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["has", "name"],
-        ["==", "class", "railway"],
-        ["==", "subclass", "station"]
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "class",
+          "railway"
+        ],
+        [
+          "==",
+          "subclass",
+          "station"
+        ]
       ],
       "layout": {
         "text-padding": 2,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-anchor": "top",
         "icon-image": "{class}_11",
         "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-offset": [0, 0.6],
+        "text-offset": [
+          0,
+          0.6
+        ],
         "text-size": 12,
         "text-max-width": 9,
         "icon-optional": false,
@@ -1712,7 +4041,11 @@
       "minzoom": 15,
       "filter": [
         "all",
-        ["==", "oneway", 1],
+        [
+          "==",
+          "oneway",
+          1
+        ],
         [
           "in",
           "class",
@@ -1732,9 +4065,22 @@
         "icon-padding": 2,
         "icon-rotation-alignment": "map",
         "icon-rotate": 90,
-        "icon-size": {"stops": [[15, 0.5], [19, 1]]}
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        }
       },
-      "paint": {"icon-opacity": 0.5}
+      "paint": {
+        "icon-opacity": 0.5
+      }
     },
     {
       "id": "road_oneway_opposite",
@@ -1744,7 +4090,11 @@
       "minzoom": 15,
       "filter": [
         "all",
-        ["==", "oneway", -1],
+        [
+          "==",
+          "oneway",
+          -1
+        ],
         [
           "in",
           "class",
@@ -1764,9 +4114,22 @@
         "icon-padding": 2,
         "icon-rotation-alignment": "map",
         "icon-rotate": -90,
-        "icon-size": {"stops": [[15, 0.5], [19, 1]]}
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        }
       },
-      "paint": {"icon-opacity": 0.5}
+      "paint": {
+        "icon-opacity": 0.5
+      }
     },
     {
       "id": "highway-name-path",
@@ -1774,10 +4137,28 @@
       "source": "openmaptiles",
       "source-layer": "transportation_name",
       "minzoom": 15.5,
-      "filter": ["==", "class", "path"],
+      "filter": [
+        "==",
+        "class",
+        "path"
+      ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]},
-        "text-font": ["Noto Sans Regular"],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-field": "{name:latin} {name:nonlatin}",
         "symbol-placement": "line",
         "text-rotation-alignment": "map"
@@ -1796,12 +4177,36 @@
       "minzoom": 15,
       "filter": [
         "all",
-        ["==", "$type", "LineString"],
-        ["in", "class", "minor", "service", "track"]
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service",
+          "track"
+        ]
       ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]},
-        "text-font": ["Noto Sans Regular"],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-field": "{name:latin} {name:nonlatin}",
         "symbol-placement": "line",
         "text-rotation-alignment": "map"
@@ -1818,10 +4223,31 @@
       "source": "openmaptiles",
       "source-layer": "transportation_name",
       "minzoom": 12.2,
-      "filter": ["in", "class", "primary", "secondary", "tertiary", "trunk"],
+      "filter": [
+        "in",
+        "class",
+        "primary",
+        "secondary",
+        "tertiary",
+        "trunk"
+      ],
       "layout": {
-        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]},
-        "text-font": ["Noto Sans Regular"],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              12
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-field": "{name:latin} {name:nonlatin}",
         "symbol-placement": "line",
         "text-rotation-alignment": "map"
@@ -1840,17 +4266,45 @@
       "minzoom": 8,
       "filter": [
         "all",
-        ["<=", "ref_length", 6],
-        ["==", "$type", "LineString"],
-        ["!in", "network", "us-interstate", "us-highway", "us-state"]
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "network",
+          "us-interstate",
+          "us-highway",
+          "us-state"
+        ]
       ],
       "layout": {
         "text-size": 10,
         "icon-image": "road_{ref_length}",
         "icon-rotation-alignment": "viewport",
         "symbol-spacing": 200,
-        "text-font": ["Noto Sans Regular"],
-        "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
+        },
         "text-rotation-alignment": "viewport",
         "icon-size": 1,
         "text-field": "{ref}"
@@ -1865,25 +4319,54 @@
       "minzoom": 7,
       "filter": [
         "all",
-        ["<=", "ref_length", 6],
-        ["==", "$type", "LineString"],
-        ["in", "network", "us-interstate"]
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-interstate"
+        ]
       ],
       "layout": {
         "text-size": 10,
         "icon-image": "{network}_{ref_length}",
         "icon-rotation-alignment": "viewport",
         "symbol-spacing": 200,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "symbol-placement": {
           "base": 1,
-          "stops": [[7, "point"], [7, "line"], [8, "line"]]
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
         },
         "text-rotation-alignment": "viewport",
         "icon-size": 1,
         "text-field": "{ref}"
       },
-      "paint": {"text-color": "rgba(19,19,19,1)"}
+      "paint": {
+        "text-color": "rgba(19,19,19,1)"
+      }
     },
     {
       "id": "highway-shield-us-other",
@@ -1893,22 +4376,51 @@
       "minzoom": 9,
       "filter": [
         "all",
-        ["<=", "ref_length", 6],
-        ["==", "$type", "LineString"],
-        ["in", "network", "us-highway", "us-state"]
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-highway",
+          "us-state"
+        ]
       ],
       "layout": {
         "text-size": 10,
         "icon-image": "{network}_{ref_length}",
         "icon-rotation-alignment": "viewport",
         "symbol-spacing": 200,
-        "text-font": ["Noto Sans Regular"],
-        "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              10,
+              "point"
+            ],
+            [
+              11,
+              "line"
+            ]
+          ]
+        },
         "text-rotation-alignment": "viewport",
         "icon-size": 1,
         "text-field": "{ref}"
       },
-      "paint": {"text-color": "rgba(19,19,19,1)"}
+      "paint": {
+        "text-color": "rgba(19,19,19,1)"
+      }
     },
     {
       "id": "airport-label-major",
@@ -1916,14 +4428,25 @@
       "source": "openmaptiles",
       "source-layer": "aerodrome_label",
       "minzoom": 10,
-      "filter": ["all", ["has", "iata"]],
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ]
+      ],
       "layout": {
         "text-padding": 2,
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-anchor": "top",
         "icon-image": "airport_11",
         "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-offset": [0, 0.6],
+        "text-offset": [
+          0,
+          0.6
+        ],
         "text-size": 12,
         "text-max-width": 9,
         "visibility": "visible",
@@ -1940,7 +4463,9 @@
     {
       "id": "place-other",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "filter": [
@@ -1954,8 +4479,22 @@
       ],
       "layout": {
         "text-letter-spacing": 0.1,
-        "text-size": {"base": 1.2, "stops": [[12, 10], [15, 14]]},
-        "text-font": ["Noto Sans Bold"],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              15,
+              14
+            ]
+          ]
+        },
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-transform": "uppercase",
         "text-max-width": 9,
@@ -1970,13 +4509,33 @@
     {
       "id": "place-village",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": ["==", "class", "village"],
+      "filter": [
+        "==",
+        "class",
+        "village"
+      ],
       "layout": {
-        "text-font": ["Noto Sans Regular"],
-        "text-size": {"base": 1.2, "stops": [[10, 12], [15, 22]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              12
+            ],
+            [
+              15,
+              22
+            ]
+          ]
+        },
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 8,
         "visibility": "visible"
@@ -1990,13 +4549,33 @@
     {
       "id": "place-town",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": ["==", "class", "town"],
+      "filter": [
+        "==",
+        "class",
+        "town"
+      ],
       "layout": {
-        "text-font": ["Noto Sans Regular"],
-        "text-size": {"base": 1.2, "stops": [[10, 14], [15, 24]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              14
+            ],
+            [
+              15,
+              24
+            ]
+          ]
+        },
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 8,
         "visibility": "visible"
@@ -2010,13 +4589,41 @@
     {
       "id": "place-city",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": ["all", ["!=", "capital", 2], ["==", "class", "city"]],
+      "filter": [
+        "all",
+        [
+          "!=",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ]
+      ],
       "layout": {
-        "text-font": ["Noto Sans Regular"],
-        "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              14
+            ],
+            [
+              11,
+              24
+            ]
+          ]
+        },
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 8,
         "visibility": "visible"
@@ -2030,17 +4637,48 @@
     {
       "id": "place-city-capital",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
-      "filter": ["all", ["==", "capital", 2], ["==", "class", "city"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "capital",
+          2
+        ],
+        [
+          "==",
+          "class",
+          "city"
+        ]
+      ],
       "layout": {
-        "text-font": ["Noto Sans Regular"],
-        "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              14
+            ],
+            [
+              11,
+              24
+            ]
+          ]
+        },
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-max-width": 8,
         "icon-image": "star_11",
-        "text-offset": [0.4, 0],
+        "text-offset": [
+          0.4,
+          0
+        ],
         "icon-size": 0.8,
         "text-anchor": "left",
         "visibility": "visible"
@@ -2054,20 +4692,46 @@
     {
       "id": "place-country-other",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "minzoom": 1.1,
       "filter": [
         "all",
-        ["==", "class", "country"],
-        [">=", "rank", 3],
-        ["!has", "iso_a2"]
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          ">=",
+          "rank",
+          3
+        ],
+        [
+          "!has",
+          "iso_a2"
+        ]
       ],
       "layout": {
-        "text-font": ["Noto Sans Italic"],
+        "text-font": [
+          "Noto Sans Italic"
+        ],
         "text-field": "{name_en}",
-        "text-size": {"stops": [[3, 11], [7, 17]]},
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              7,
+              17
+            ]
+          ]
+        },
         "text-transform": "uppercase",
         "text-max-width": 6.25,
         "visibility": "visible"
@@ -2082,20 +4746,46 @@
     {
       "id": "place-country-3",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "minzoom": 1.1,
       "filter": [
         "all",
-        ["==", "class", "country"],
-        [">=", "rank", 3],
-        ["has", "iso_a2"]
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          ">=",
+          "rank",
+          3
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
       ],
       "layout": {
-        "text-font": ["Noto Sans Bold"],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-field": "{name_en}",
-        "text-size": {"stops": [[3, 11], [7, 17]]},
+        "text-size": {
+          "stops": [
+            [
+              3,
+              11
+            ],
+            [
+              7,
+              17
+            ]
+          ]
+        },
         "text-transform": "uppercase",
         "text-max-width": 6.25,
         "visibility": "visible"
@@ -2110,20 +4800,46 @@
     {
       "id": "place-country-2",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "minzoom": 1.1,
       "filter": [
         "all",
-        ["==", "class", "country"],
-        ["==", "rank", 2],
-        ["has", "iso_a2"]
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "==",
+          "rank",
+          2
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
       ],
       "layout": {
-        "text-font": ["Noto Sans Bold"],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-field": "{name_en}",
-        "text-size": {"stops": [[2, 11], [5, 17]]},
+        "text-size": {
+          "stops": [
+            [
+              2,
+              11
+            ],
+            [
+              5,
+              17
+            ]
+          ]
+        },
         "text-transform": "uppercase",
         "text-max-width": 6.25,
         "visibility": "visible"
@@ -2138,20 +4854,46 @@
     {
       "id": "place-country-1",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "minzoom": 1.1,
       "filter": [
         "all",
-        ["==", "class", "country"],
-        ["==", "rank", 1],
-        ["has", "iso_a2"]
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "==",
+          "rank",
+          1
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
       ],
       "layout": {
-        "text-font": ["Noto Sans Bold"],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-field": "{name_en}",
-        "text-size": {"stops": [[1, 11], [4, 17]]},
+        "text-size": {
+          "stops": [
+            [
+              1,
+              11
+            ],
+            [
+              4,
+              17
+            ]
+          ]
+        },
         "text-transform": "uppercase",
         "text-max-width": 6.25,
         "visibility": "visible"
@@ -2166,13 +4908,21 @@
     {
       "id": "place-continent",
       "type": "symbol",
-      "metadata": {"mapbox:group": "1444849242106.713"},
+      "metadata": {
+        "mapbox:group": "1444849242106.713"
+      },
       "source": "openmaptiles",
       "source-layer": "place",
       "maxzoom": 1.1,
-      "filter": ["==", "class", "continent"],
+      "filter": [
+        "==",
+        "class",
+        "continent"
+      ],
       "layout": {
-        "text-font": ["Noto Sans Bold"],
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-field": "{name_en}",
         "text-size": 14,
         "text-max-width": 6.25,

--- a/style.json
+++ b/style.json
@@ -1,44 +1,50 @@
 {
   "version": 8,
-  "name": "OSM Bright-desaturated",
+  "name": "Bright-desaturated",
   "metadata": {
-    "mapbox:type": "template",
+    "mapbox:autocomposite": false,
     "mapbox:groups": {
-      "1444849364238.8171": {
-        "collapsed": false,
-        "name": "Buildings"
-      },
-      "1444849354174.1904": {
-        "collapsed": true,
-        "name": "Tunnels"
-      },
-      "1444849388993.3071": {
-        "collapsed": false,
-        "name": "Land"
-      },
       "1444849242106.713": {
         "collapsed": false,
         "name": "Places"
       },
-      "1444849382550.77": {
-        "collapsed": false,
-        "name": "Water"
+      "1444849334699.1902": {
+        "collapsed": true,
+        "name": "Bridges"
       },
       "1444849345966.4436": {
         "collapsed": false,
         "name": "Roads"
       },
-      "1444849334699.1902": {
+      "1444849354174.1904": {
         "collapsed": true,
-        "name": "Bridges"
+        "name": "Tunnels"
+      },
+      "1444849364238.8171": {
+        "collapsed": false,
+        "name": "Buildings"
+      },
+      "1444849382550.77": {
+        "collapsed": false,
+        "name": "Water"
+      },
+      "1444849388993.3071": {
+        "collapsed": false,
+        "name": "Land"
       }
     },
-    "mapbox:autocomposite": false,
-    "openmaptiles:version": "3.x",
+    "mapbox:type": "template",
     "openmaptiles:mapbox:owner": "openmaptiles",
     "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t",
-    "maputnik:renderer": "mbgljs"
+    "openmaptiles:version": "3.x"
   },
+  "center": [
+    0,
+    0
+  ],
+  "zoom": 1,
+  "bearing": 0,
+  "pitch": 0,
   "sources": {
     "openmaptiles": {
       "type": "vector",
@@ -97,10 +103,18 @@
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": [
-        "==",
-        "class",
-        "residential"
+        "all",
+        [
+          "in",
+          "class",
+          "residential",
+          "suburb",
+          "neighbourhood"
+        ]
       ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "base": 1,
@@ -138,6 +152,9 @@
           "commercial"
         ]
       ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(228,228,228,0.23)"
       }
@@ -145,9 +162,6 @@
     {
       "id": "landuse-industrial",
       "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": [
@@ -158,77 +172,18 @@
           "Polygon"
         ],
         [
-          "==",
+          "in",
           "class",
-          "industrial"
+          "industrial",
+          "garages",
+          "dam"
         ]
       ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(255,255,249,0.34)"
-      }
-    },
-    {
-      "id": "park",
-      "type": "fill",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "source": "openmaptiles",
-      "source-layer": "park",
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
-      "paint": {
-        "fill-color": "rgba(244,244,244,1)",
-        "fill-opacity": {
-          "base": 1.8,
-          "stops": [
-            [
-              9,
-              0.5
-            ],
-            [
-              12,
-              0.2
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "park-outline",
-      "type": "line",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "source": "openmaptiles",
-      "source-layer": "park",
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
-      "layout": {},
-      "paint": {
-        "line-color": {
-          "base": 1,
-          "stops": [
-            [
-              6,
-              "rgba(149,186,121,0.36)"
-            ],
-            [
-              8,
-              "rgba(149,186,121,0.66)"
-            ]
-          ]
-        },
-        "line-dasharray": [
-          3,
-          3
-        ]
       }
     },
     {
@@ -295,6 +250,9 @@
         "class",
         "railway"
       ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "rgba(248,248,248,0.4)"
       }
@@ -313,9 +271,6 @@
         "wood"
       ],
       "paint": {
-        "fill-color": "rgba(138,181,113,1)",
-        "fill-opacity": 0.1,
-        "fill-outline-color": "rgba(19,19,19,0.03)",
         "fill-antialias": {
           "base": 1,
           "stops": [
@@ -328,7 +283,10 @@
               true
             ]
           ]
-        }
+        },
+        "fill-color": "rgba(138,181,113,1)",
+        "fill-opacity": 0.1,
+        "fill-outline-color": "rgba(19,19,19,0.03)"
       }
     },
     {
@@ -389,10 +347,15 @@
         ]
       ],
       "layout": {
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
+        "line-dasharray": [
+          2,
+          4
+        ],
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -405,11 +368,7 @@
               6
             ]
           ]
-        },
-        "line-dasharray": [
-          2,
-          4
-        ]
+        }
       }
     },
     {
@@ -421,17 +380,74 @@
       "source": "openmaptiles",
       "source-layer": "waterway",
       "filter": [
-        "!in",
-        "class",
-        "canal",
-        "river",
-        "stream"
+        "all",
+        [
+          "!in",
+          "class",
+          "canal",
+          "river",
+          "stream"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
+        ]
       ],
       "layout": {
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-other-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "!in",
+          "class",
+          "canal",
+          "river",
+          "stream"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(207,213,221,1)",
+        "line-dasharray": [
+          4,
+          3
+        ],
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -467,13 +483,71 @@
           "!=",
           "brunnel",
           "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
         ]
       ],
       "layout": {
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-stream-canal-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(207,213,221,1)",
+        "line-dasharray": [
+          4,
+          3
+        ],
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -508,13 +582,70 @@
           "!=",
           "brunnel",
           "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          0
         ]
       ],
       "layout": {
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(207,213,221,1)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway-river-intermittent",
+      "type": "line",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "intermittent",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(207,213,221,1)",
+        "line-dasharray": [
+          3,
+          2.5
+        ],
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -548,8 +679,8 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-opacity": 1,
         "fill-color": "rgba(207,213,221,1)",
+        "fill-opacity": 1,
         "fill-translate": {
           "base": 1,
           "stops": [
@@ -620,6 +751,30 @@
       }
     },
     {
+      "id": "landcover-sand",
+      "type": "fill",
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "sand"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgba(255,254,242,1)",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "building",
       "type": "fill",
       "metadata": {
@@ -628,6 +783,7 @@
       "source": "openmaptiles",
       "source-layer": "building",
       "paint": {
+        "fill-antialias": true,
         "fill-color": {
           "base": 1,
           "stops": [
@@ -640,8 +796,7 @@
               "rgba(236,236,236,1)"
             ]
           ]
-        },
-        "fill-antialias": true
+        }
       }
     },
     {
@@ -656,6 +811,21 @@
         "visibility": "visible"
       },
       "paint": {
+        "fill-color": "rgba(252,252,252,1)",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        },
+        "fill-outline-color": "rgba(236,236,236,1)",
         "fill-translate": {
           "base": 1,
           "stops": [
@@ -672,21 +842,6 @@
                 -2,
                 -2
               ]
-            ]
-          ]
-        },
-        "fill-outline-color": "rgba(236,236,236,1)",
-        "fill-color": "rgba(252,252,252,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
             ]
           ]
         }
@@ -1253,6 +1408,10 @@
       ],
       "paint": {
         "line-color": "rgba(203,203,203,1)",
+        "line-dasharray": [
+          2,
+          2
+        ],
         "line-width": {
           "base": 1.4,
           "stops": [
@@ -1269,11 +1428,7 @@
               2
             ]
           ]
-        },
-        "line-dasharray": [
-          2,
-          2
-        ]
+        }
       }
     },
     {
@@ -1295,11 +1450,11 @@
       },
       "paint": {
         "line-color": "rgba(167,168,169,1)",
-        "line-width": 1.1,
         "line-dasharray": [
           2,
           2
-        ]
+        ],
+        "line-width": 1.1
       }
     },
     {
@@ -1326,6 +1481,7 @@
       },
       "paint": {
         "line-color": "rgba(169,169,169,1)",
+        "line-opacity": 1,
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -1338,8 +1494,7 @@
               12
             ]
           ]
-        },
-        "line-opacity": 1
+        }
       }
     },
     {
@@ -1366,6 +1521,7 @@
       },
       "paint": {
         "line-color": "rgba(169,169,169,1)",
+        "line-opacity": 1,
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -1378,8 +1534,7 @@
               55
             ]
           ]
-        },
-        "line-opacity": 1
+        }
       }
     },
     {
@@ -1409,6 +1564,7 @@
         "visibility": "visible"
       },
       "paint": {
+        "fill-color": "rgba(255,255,255,1)",
         "fill-opacity": {
           "base": 1,
           "stops": [
@@ -1421,8 +1577,7 @@
               1
             ]
           ]
-        },
-        "fill-color": "rgba(255,255,255,1)"
+        }
       }
     },
     {
@@ -1454,19 +1609,6 @@
       },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              17,
-              10
-            ]
-          ]
-        },
         "line-opacity": {
           "base": 1,
           "stops": [
@@ -1477,6 +1619,19 @@
             [
               12,
               1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              17,
+              10
             ]
           ]
         }
@@ -1511,6 +1666,19 @@
       },
       "paint": {
         "line-color": "rgba(255,255,255,1)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -1523,17 +1691,71 @@
               50
             ]
           ]
-        },
-        "line-opacity": {
-          "base": 1,
+        }
+      }
+    },
+    {
+      "id": "road_area_pier",
+      "type": "fill",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "rgba(255,255,255,1)"
+      }
+    },
+    {
+      "id": "road_pier",
+      "type": "line",
+      "metadata": {},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "pier"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgba(255,255,255,1)",
+        "line-width": {
+          "base": 1.2,
           "stops": [
             [
-              11,
-              0
+              15,
+              1
             ],
             [
-              12,
-              1
+              17,
+              4
             ]
           ]
         }
@@ -1548,18 +1770,26 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
-        "==",
-        "$type",
-        "Polygon"
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!in",
+          "class",
+          "pier"
+        ]
       ],
       "layout": {
         "visibility": "visible"
       },
       "paint": {
+        "fill-antialias": false,
         "fill-color": "rgba(244,244,244,0.56)",
-        "fill-outline-color": "rgba(222,222,222,1)",
         "fill-opacity": 0.9,
-        "fill-antialias": false
+        "fill-outline-color": "rgba(222,222,222,1)"
       }
     },
     {
@@ -1950,6 +2180,18 @@
       },
       "paint": {
         "line-color": "rgba(228,195,168,1)",
+        "line-opacity": {
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -1972,18 +2214,6 @@
             [
               20,
               22
-            ]
-          ]
-        },
-        "line-opacity": {
-          "stops": [
-            [
-              4,
-              0
-            ],
-            [
-              5,
-              1
             ]
           ]
         }
@@ -3066,6 +3296,10 @@
       ],
       "paint": {
         "line-color": "rgba(206,206,206,1)",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -3078,11 +3312,7 @@
               4
             ]
           ]
-        },
-        "line-dasharray": [
-          1.5,
-          0.75
-        ]
+        }
       }
     },
     {
@@ -3423,8 +3653,8 @@
         "cable_car"
       ],
       "layout": {
-        "visibility": "visible",
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(195,195,195,1)",
@@ -3455,11 +3685,15 @@
         "cable_car"
       ],
       "layout": {
-        "visibility": "visible",
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(195,195,195,1)",
+        "line-dasharray": [
+          2,
+          3
+        ],
         "line-width": {
           "base": 1,
           "stops": [
@@ -3472,11 +3706,7 @@
               5.5
             ]
           ]
-        },
-        "line-dasharray": [
-          2,
-          3
-        ]
+        }
       }
     },
     {
@@ -3503,7 +3733,8 @@
         ]
       ],
       "layout": {
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(173,173,173,1)",
@@ -3557,7 +3788,8 @@
       ],
       "layout": {
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(179,179,179,1)",
@@ -3604,7 +3836,8 @@
       ],
       "layout": {
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(190,190,190,1)",
@@ -3640,6 +3873,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
+      "minzoom": 4,
       "filter": [
         "all",
         [
@@ -3656,10 +3890,23 @@
       ],
       "layout": {
         "line-cap": "round",
-        "line-join": "round"
+        "line-join": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(201,201,201,1)",
+        "line-opacity": {
+          "stops": [
+            [
+              6,
+              0.6
+            ],
+            [
+              10,
+              1
+            ]
+          ]
+        },
         "line-width": {
           "base": 1,
           "stops": [
@@ -3678,18 +3925,6 @@
             [
               12,
               8
-            ]
-          ]
-        },
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.6
-            ],
-            [
-              10,
-              1
             ]
           ]
         }
@@ -3714,21 +3949,21 @@
         ]
       ],
       "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin} {name:nonlatin}",
         "text-font": [
           "Noto Sans Italic"
         ],
-        "text-size": 14,
-        "text-field": "{name:latin} {name:nonlatin}",
+        "text-letter-spacing": 0.2,
         "text-max-width": 5,
         "text-rotation-alignment": "map",
-        "symbol-placement": "line",
-        "text-letter-spacing": 0.2,
-        "symbol-spacing": 350
+        "text-size": 14
       },
       "paint": {
         "text-color": "rgba(167,187,214,1)",
-        "text-halo-width": 1.5,
-        "text-halo-color": "rgba(255,255,255,0.7)"
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
       }
     },
     {
@@ -3742,21 +3977,21 @@
         "LineString"
       ],
       "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Italic"
         ],
-        "text-size": 14,
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-letter-spacing": 0.2,
         "text-max-width": 5,
         "text-rotation-alignment": "map",
-        "symbol-placement": "line",
-        "symbol-spacing": 350,
-        "text-letter-spacing": 0.2
+        "text-size": 14
       },
       "paint": {
         "text-color": "rgba(167,187,214,1)",
-        "text-halo-width": 1.5,
-        "text-halo-color": "rgba(255,255,255,0.7)"
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
       }
     },
     {
@@ -3779,21 +4014,21 @@
         ]
       ],
       "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}",
         "text-font": [
           "Noto Sans Italic"
         ],
-        "text-size": 14,
-        "text-field": "{name:latin}",
+        "text-letter-spacing": 0.2,
         "text-max-width": 5,
         "text-rotation-alignment": "map",
-        "symbol-placement": "point",
-        "symbol-spacing": 350,
-        "text-letter-spacing": 0.2
+        "text-size": 14
       },
       "paint": {
         "text-color": "rgba(167,187,214,1)",
-        "text-halo-width": 1.5,
-        "text-halo-color": "rgba(255,255,255,0.7)"
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
       }
     },
     {
@@ -3816,9 +4051,15 @@
         ]
       ],
       "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Italic"
         ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
         "text-size": {
           "stops": [
             [
@@ -3831,18 +4072,12 @@
             ]
           ]
         },
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-max-width": 5,
-        "text-rotation-alignment": "map",
-        "symbol-placement": "point",
-        "symbol-spacing": 350,
-        "text-letter-spacing": 0.2,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(167,187,214,1)",
-        "text-halo-width": 1.5,
-        "text-halo-color": "rgba(255,255,255,0.7)"
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
       }
     },
     {
@@ -3862,28 +4097,41 @@
           ">=",
           "rank",
           25
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
         ]
       ],
       "layout": {
-        "text-padding": 2,
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-anchor": "top",
-        "icon-image": "{class}_11",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-max-width": 9,
         "text-offset": [
           0,
           0.6
         ],
+        "text-padding": 2,
         "text-size": 12,
-        "text-max-width": 9
+        "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(117,117,117,1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1)"
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255,255,255,1)",
+        "text-halo-width": 1
       }
     },
     {
@@ -3908,28 +4156,41 @@
           ">=",
           "rank",
           15
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
         ]
       ],
       "layout": {
-        "text-padding": 2,
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-anchor": "top",
-        "icon-image": "{class}_11",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-max-width": 9,
         "text-offset": [
           0,
           0.6
         ],
+        "text-padding": 2,
         "text-size": 12,
-        "text-max-width": 9
+        "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(117,117,117,1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1)"
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255,255,255,1)",
+        "text-halo-width": 1
       }
     },
     {
@@ -3953,28 +4214,41 @@
         [
           "has",
           "name"
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
         ]
       ],
       "layout": {
-        "text-padding": 2,
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-anchor": "top",
-        "icon-image": "{class}_11",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-max-width": 9,
         "text-offset": [
           0,
           0.6
         ],
+        "text-padding": 2,
         "text-size": 12,
-        "text-max-width": 9
+        "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(117,117,117,1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1)"
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255,255,255,1)",
+        "text-halo-width": 1
       }
     },
     {
@@ -4006,31 +4280,31 @@
         ]
       ],
       "layout": {
-        "text-padding": 2,
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-image": "{class}_11",
+        "icon-optional": false,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-anchor": "top",
-        "icon-image": "{class}_11",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-ignore-placement": false,
+        "text-max-width": 9,
         "text-offset": [
           0,
           0.6
         ],
-        "text-size": 12,
-        "text-max-width": 9,
-        "icon-optional": false,
-        "icon-ignore-placement": false,
-        "icon-allow-overlap": false,
-        "text-ignore-placement": false,
-        "text-allow-overlap": false,
-        "text-optional": true
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(117,117,117,1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1)"
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255,255,255,1)",
+        "text-halo-width": 1
       }
     },
     {
@@ -4059,12 +4333,10 @@
         ]
       ],
       "layout": {
-        "symbol-placement": "line",
         "icon-image": "oneway",
-        "symbol-spacing": 75,
         "icon-padding": 2,
-        "icon-rotation-alignment": "map",
         "icon-rotate": 90,
+        "icon-rotation-alignment": "map",
         "icon-size": {
           "stops": [
             [
@@ -4076,7 +4348,9 @@
               1
             ]
           ]
-        }
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
       },
       "paint": {
         "icon-opacity": 0.5
@@ -4108,12 +4382,10 @@
         ]
       ],
       "layout": {
-        "symbol-placement": "line",
         "icon-image": "oneway",
-        "symbol-spacing": 75,
         "icon-padding": 2,
-        "icon-rotation-alignment": "map",
         "icon-rotate": -90,
+        "icon-rotation-alignment": "map",
         "icon-size": {
           "stops": [
             [
@@ -4125,7 +4397,9 @@
               1
             ]
           ]
-        }
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
       },
       "paint": {
         "icon-opacity": 0.5
@@ -4143,6 +4417,12 @@
         "path"
       ],
       "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
         "text-size": {
           "base": 1,
           "stops": [
@@ -4155,17 +4435,11 @@
               13
             ]
           ]
-        },
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-field": "{name:latin} {name:nonlatin}",
-        "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        }
       },
       "paint": {
-        "text-halo-color": "rgba(255,255,255,1)",
         "text-color": "rgba(178,178,178,1)",
+        "text-halo-color": "rgba(255,255,255,1)",
         "text-halo-width": 0.5
       }
     },
@@ -4191,6 +4465,12 @@
         ]
       ],
       "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
         "text-size": {
           "base": 1,
           "stops": [
@@ -4203,17 +4483,11 @@
               13
             ]
           ]
-        },
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-field": "{name:latin} {name:nonlatin}",
-        "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        }
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(120,120,120,1)",
+        "text-halo-blur": 0.5,
         "text-halo-width": 1
       }
     },
@@ -4232,6 +4506,12 @@
         "trunk"
       ],
       "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-rotation-alignment": "map",
         "text-size": {
           "base": 1,
           "stops": [
@@ -4244,17 +4524,11 @@
               13
             ]
           ]
-        },
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-field": "{name:latin} {name:nonlatin}",
-        "symbol-placement": "line",
-        "text-rotation-alignment": "map"
+        }
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(120,120,120,1)",
+        "text-halo-blur": 0.5,
         "text-halo-width": 1
       }
     },
@@ -4285,13 +4559,9 @@
         ]
       ],
       "layout": {
-        "text-size": 10,
         "icon-image": "road_{ref_length}",
         "icon-rotation-alignment": "viewport",
-        "symbol-spacing": 200,
-        "text-font": [
-          "Noto Sans Regular"
-        ],
+        "icon-size": 1,
         "symbol-placement": {
           "base": 1,
           "stops": [
@@ -4305,9 +4575,13 @@
             ]
           ]
         },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-rotation-alignment": "viewport",
-        "icon-size": 1,
-        "text-field": "{ref}"
+        "text-size": 10
       },
       "paint": {}
     },
@@ -4336,13 +4610,9 @@
         ]
       ],
       "layout": {
-        "text-size": 10,
         "icon-image": "{network}_{ref_length}",
         "icon-rotation-alignment": "viewport",
-        "symbol-spacing": 200,
-        "text-font": [
-          "Noto Sans Regular"
-        ],
+        "icon-size": 1,
         "symbol-placement": {
           "base": 1,
           "stops": [
@@ -4360,9 +4630,13 @@
             ]
           ]
         },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-rotation-alignment": "viewport",
-        "icon-size": 1,
-        "text-field": "{ref}"
+        "text-size": 10
       },
       "paint": {
         "text-color": "rgba(19,19,19,1)"
@@ -4394,13 +4668,9 @@
         ]
       ],
       "layout": {
-        "text-size": 10,
         "icon-image": "{network}_{ref_length}",
         "icon-rotation-alignment": "viewport",
-        "symbol-spacing": 200,
-        "text-font": [
-          "Noto Sans Regular"
-        ],
+        "icon-size": 1,
         "symbol-placement": {
           "base": 1,
           "stops": [
@@ -4414,9 +4684,13 @@
             ]
           ]
         },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-rotation-alignment": "viewport",
-        "icon-size": 1,
-        "text-field": "{ref}"
+        "text-size": 10
       },
       "paint": {
         "text-color": "rgba(19,19,19,1)"
@@ -4436,28 +4710,28 @@
         ]
       ],
       "layout": {
-        "text-padding": 2,
+        "icon-image": "airport_11",
+        "icon-size": 1,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
-        "text-anchor": "top",
-        "icon-image": "airport_11",
-        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-max-width": 9,
         "text-offset": [
           0,
           0.6
         ],
+        "text-optional": true,
+        "text-padding": 2,
         "text-size": 12,
-        "text-max-width": 9,
-        "visibility": "visible",
-        "icon-size": 1,
-        "text-optional": true
+        "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 0.5,
         "text-color": "rgba(117,117,117,1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255,255,255,1)"
+        "text-halo-blur": 0.5,
+        "text-halo-color": "rgba(255,255,255,1)",
+        "text-halo-width": 1
       }
     },
     {
@@ -4478,7 +4752,12 @@
         "continent"
       ],
       "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Bold"
+        ],
         "text-letter-spacing": 0.1,
+        "text-max-width": 9,
         "text-size": {
           "base": 1.2,
           "stops": [
@@ -4492,18 +4771,13 @@
             ]
           ]
         },
-        "text-font": [
-          "Noto Sans Bold"
-        ],
-        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-transform": "uppercase",
-        "text-max-width": 9,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(89,77,76,1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
       }
     },
     {
@@ -4520,9 +4794,11 @@
         "village"
       ],
       "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
+        "text-max-width": 8,
         "text-size": {
           "base": 1.2,
           "stops": [
@@ -4536,14 +4812,12 @@
             ]
           ]
         },
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-max-width": 8,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(64,64,64,1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
       }
     },
     {
@@ -4560,9 +4834,11 @@
         "town"
       ],
       "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
+        "text-max-width": 8,
         "text-size": {
           "base": 1.2,
           "stops": [
@@ -4576,14 +4852,12 @@
             ]
           ]
         },
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-max-width": 8,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(64,64,64,1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
       }
     },
     {
@@ -4608,9 +4882,11 @@
         ]
       ],
       "layout": {
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
         ],
+        "text-max-width": 8,
         "text-size": {
           "base": 1.2,
           "stops": [
@@ -4624,14 +4900,12 @@
             ]
           ]
         },
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-max-width": 8,
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(64,64,64,1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
       }
     },
     {
@@ -4656,8 +4930,17 @@
         ]
       ],
       "layout": {
+        "icon-image": "star_11",
+        "icon-size": 0.8,
+        "text-anchor": "left",
+        "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": [
           "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0.4,
+          0
         ],
         "text-size": {
           "base": 1.2,
@@ -4672,21 +4955,12 @@
             ]
           ]
         },
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-max-width": 8,
-        "icon-image": "star_11",
-        "text-offset": [
-          0.4,
-          0
-        ],
-        "icon-size": 0.8,
-        "text-anchor": "left",
         "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(64,64,64,1)",
-        "text-halo-width": 1.2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
       }
     },
     {
@@ -4737,10 +5011,10 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(66,66,66,1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
       }
     },
     {
@@ -4791,10 +5065,10 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(66,66,66,1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
       }
     },
     {
@@ -4845,10 +5119,10 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(66,66,66,1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
       }
     },
     {
@@ -4899,10 +5173,10 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(66,66,66,1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
       }
     },
     {
@@ -4930,12 +5204,12 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-halo-blur": 1,
         "text-color": "rgba(66,66,66,1)",
-        "text-halo-width": 2,
-        "text-halo-color": "rgba(255,255,255,0.8)"
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 2
       }
     }
   ],
-  "id": "osm-bright"
+  "id": "bright"
 }


### PR DESCRIPTION
Update from the [bright style PR](https://github.com/elastic/osm-bright-gl-style/pull/6) that updated to upstream version 1.9.


[Preview](https://elastic.github.io/ems-basemap-editor/comparator.html?style=osm-bright-desaturated&github=jsanz/osm-bright-desaturated-gl-style&ref=omt1.9#1/0/0)

![image](https://user-images.githubusercontent.com/188264/177347043-eb0845ab-582c-4ca1-95e0-76c1f1de57a1.png)
