### PR TITLE
Remove dynamic opacity in the Light style

### DIFF
--- a/layers/aeroway/style.json
+++ b/layers/aeroway/style.json
@@ -90,7 +90,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "aeroway",
-      "minzoom": 4,
+      "minzoom": 12,
       "filter": [
         "all",
         [
@@ -110,19 +110,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              14,
-              1
-            ]
-          ]
-        }
+        "fill-opacity": 1
       },
       "order": 40
     },

--- a/layers/building/style.json
+++ b/layers/building/style.json
@@ -39,19 +39,7 @@
       },
       "paint": {
         "fill-color": "rgba(252,252,252,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
-            ]
-          ]
-        },
+        "fill-opacity": 1,
         "fill-outline-color": "rgba(236,236,236,1)",
         "fill-translate": {
           "base": 1,
@@ -73,6 +61,7 @@
           ]
         }
       },
+      "minzoom": 14,
       "order": 24
     }
   ]

--- a/layers/landcover/style.json
+++ b/layers/landcover/style.json
@@ -18,19 +18,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
+        "fill-opacity": 0.9
       },
       "order": 1
     },
@@ -104,19 +92,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
+        "fill-opacity": 1
       },
       "order": 21
     },

--- a/style.json
+++ b/style.json
@@ -81,19 +81,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
+        "fill-opacity": 0.9
       }
     },
     {
@@ -732,19 +720,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
+        "fill-opacity": 1
       }
     },
     {
@@ -809,19 +785,7 @@
       },
       "paint": {
         "fill-color": "rgba(252,252,252,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
-            ]
-          ]
-        },
+        "fill-opacity": 1,
         "fill-outline-color": "rgba(236,236,236,1)",
         "fill-translate": {
           "base": 1,
@@ -842,7 +806,8 @@
             ]
           ]
         }
-      }
+      },
+      "minzoom": 14
     },
     {
       "id": "tunnel-service-track-casing",
@@ -1542,7 +1507,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "aeroway",
-      "minzoom": 4,
+      "minzoom": 12,
       "filter": [
         "all",
         [
@@ -1562,19 +1527,7 @@
       },
       "paint": {
         "fill-color": "rgba(255,255,255,1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              14,
-              1
-            ]
-          ]
-        }
+        "fill-opacity": 1
       }
     },
     {


### PR DESCRIPTION
Related to elastic/osm-bright-gl-style#11

Similar to elastic/osm-bright-gl-style#12 but in this case changes are fewer since the only layers affected are:

* `landcover-wood`
* `landcover-glacier
* `landcover-ice-shelf`
* `building-top`
* `aeroway-area`


### Preview and screenshots

[`master` versus this PR](https://stamen.github.io/maperture/#map=7.63/40.3618/-3.7542/0/0&showCollisions=false&showBoundaries=false&showDiff=false&viewMode=mirror&maps=%5B%7B%22name%22%3A%22Bright-desaturated%22%2C%22type%22%3A%22mapbox-gl%22%2C%22renderer%22%3A%22mapbox-gl%22%2C%22url%22%3A%22https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fosm-bright-desaturated-gl-style%2Fmaster%2Fstyle.json%22%2C%22id%22%3A%22bright%22%2C%22index%22%3A0%7D%2C%7B%22name%22%3A%22Bright-desaturated%22%2C%22type%22%3A%22mapbox-gl%22%2C%22renderer%22%3A%22mapbox-gl%22%2C%22url%22%3A%22https%3A%2F%2Fraw.githubusercontent.com%2Fjsanz%2Fosm-bright-desaturated-gl-style%2Fremove-dynamic-opacity%2Fstyle.json%22%2C%22id%22%3A%22bright%22%2C%22index%22%3A1%7D%5D) (we can't only do here up to zoom 10).

![image](https://github.com/elastic/osm-bright-desaturated-gl-style/assets/188264/8394a9e2-a55f-454b-a741-3ea3b23bcab3)

![image](https://github.com/elastic/osm-bright-desaturated-gl-style/assets/188264/3fae9603-5053-477a-ba4d-c81e9bfacc6e)

